### PR TITLE
feat: add new session link and dynamic node imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,25 +1,21 @@
 {
-    "env": {
-        "browser": true,
-        "es2021": true
-    },
-    "globals": {
-        "OT": true
-    },
-    "extends": [
-        "airbnb-base",
-        "prettier"
-    ],
-    "plugins": ["prettier"],
-    "parserOptions": {
-        "ecmaVersion": "latest",
-        "sourceType": "module"
-    },
-    "rules": {
-        "prettier/prettier": ["error", { "singleQuote": true }],
-        "no-use-before-define": [
-            "error",
-            { "functions": false }
-        ]
-    }
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "globals": {
+    "OT": true
+  },
+  "extends": ["airbnb-base", "prettier"],
+  "plugins": ["prettier"],
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "rules": {
+    "prettier/prettier": ["error", { "singleQuote": true }],
+    "no-use-before-define": ["error", { "functions": false }],
+    "no-console": ["error", { "allow": ["warn", "error"] }],
+    "no-alert": "off"
+  }
 }

--- a/netlify/functions/session.js
+++ b/netlify/functions/session.js
@@ -21,7 +21,7 @@ exports.handler = async function handler() {
 
   try {
     session = await new Promise((resolve, reject) => {
-      ot.createSession({ mediaMode: 'routed' }, (error, sess) => {
+      ot.createSession({ mediaMode: 'relayed' }, (error, sess) => {
         if (error) {
           reject(error);
         }

--- a/netlify/functions/session.js
+++ b/netlify/functions/session.js
@@ -1,7 +1,8 @@
-const OpenTok = require('daily-opentok-node');
-// const OpenTok = require("opentok");
+const useDaily = process.env.USE_DAILY;
+const OpenTok =
+  useDaily === 'TRUE' ? require('daily-opentok-node') : require('opentok');
 
-exports.handler = async function () {
+exports.handler = async function handler() {
   // In the case of our default Vonage flow, the OpenTok instance
   // will be created by passing in Vonage API key and secret
   let initParam1 = process.env.VONAGE_API_KEY;
@@ -10,17 +11,17 @@ exports.handler = async function () {
   // In case of Daily provider flow, the OpenTok instance
   // will be created by passing in a Daily API Key
   // and empty string.
-  const useDaily = process.env.USE_DAILY;
   if (useDaily === 'TRUE') {
     initParam1 = process.env.DAILY_API_KEY;
     initParam2 = '';
   }
+
   const ot = new OpenTok(initParam1, initParam2);
   let session;
 
   try {
     session = await new Promise((resolve, reject) => {
-      ot.createSession({ mediaMode: 'relayed' }, (error, sess) => {
+      ot.createSession({ mediaMode: 'routed' }, (error, sess) => {
         if (error) {
           reject(error);
         }

--- a/netlify/functions/token.js
+++ b/netlify/functions/token.js
@@ -1,7 +1,8 @@
-const OpenTok = require('daily-opentok-node');
-// const OpenTok = require("opentok");
+const useDaily = process.env.USE_DAILY;
+const OpenTok =
+  useDaily === 'TRUE' ? require('daily-opentok-node') : require('opentok');
 
-exports.handler = async function (event) {
+exports.handler = async function handler(event) {
   const gotSessionID = event.queryStringParameters.sessionID;
 
   // In the case of our default Vonage flow, the OpenTok instance
@@ -13,7 +14,6 @@ exports.handler = async function (event) {
   // will be created by passing in empty string and
   // Daily API key. The second parameter CAN also be
   // a pre-fetched Daily Domain ID if desired.
-  const useDaily = process.env.USE_DAILY;
   if (useDaily === 'TRUE') {
     initParam1 = process.env.DAILY_API_KEY;
     initParam2 = '';

--- a/src/call.js
+++ b/src/call.js
@@ -2,7 +2,7 @@
 // https://stackoverflow.com/questions/60064861/opentok-toxbox-keep-the-api-key-secret
 // When using Daily's OpenTok shim,
 // the API key is not used and can be set to anything.
-const apiKey = '47542751';
+const apiKey = '47542851'; // Replace this with process.env maybe?
 
 main();
 
@@ -116,6 +116,11 @@ async function initializeSession(sessionID) {
     }
   });
 
+  const link = document.createElement('a');
+  link.href = `/?sessionID=${sessionID}`;
+  link.target = '_blank';
+  link.text = `Click to join session ${sessionID} from another window`;
+
   const info = document.getElementById('sessionInfo');
-  info.innerText = sessionID;
+  info.appendChild(link);
 }

--- a/src/call.js
+++ b/src/call.js
@@ -2,7 +2,7 @@
 // https://stackoverflow.com/questions/60064861/opentok-toxbox-keep-the-api-key-secret
 // When using Daily's OpenTok shim,
 // the API key is not used and can be set to anything.
-const apiKey = 'Your Opentok API Key';
+const apiKey = '47542851';
 
 main();
 

--- a/src/call.js
+++ b/src/call.js
@@ -2,7 +2,7 @@
 // https://stackoverflow.com/questions/60064861/opentok-toxbox-keep-the-api-key-secret
 // When using Daily's OpenTok shim,
 // the API key is not used and can be set to anything.
-const apiKey = '47542851'; // Replace this with process.env maybe?
+const apiKey = 'Your Opentok API Key';
 
 main();
 

--- a/src/index.html
+++ b/src/index.html
@@ -1,17 +1,17 @@
 <html>
-<head>
-    <title> OpenTok Getting Started </title>
-    <link href="style.css" rel="stylesheet" type="text/css">
-    <script src="https://unpkg.com/daily-opentok-client/dist/opentok.iife.js"></script>
-    <!--script src="https://static.opentok.com/v2/js/opentok.min.js"></script-->
-</head>
-<body>
+  <head>
+    <title>OpenTok Getting Started</title>
+    <link href="style.css" rel="stylesheet" type="text/css" />
+    <!-- <script src="https://unpkg.com/daily-opentok-client/dist/opentok.iife.js"></script> -->
+    <script src="https://static.opentok.com/v2/js/opentok.min.js"></script>
+  </head>
+  <body>
     <div id="sessionInfo"></div>
 
     <div id="videos">
-        <div id="subscriber"></div>
-        <div id="publisher"></div>
+      <div id="subscriber"></div>
+      <div id="publisher"></div>
     </div>
     <script type="text/javascript" src="call.js" type="module"></script>
-</body>
+  </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -2,8 +2,8 @@
   <head>
     <title>OpenTok Getting Started</title>
     <link href="style.css" rel="stylesheet" type="text/css" />
-    <!-- <script src="https://unpkg.com/daily-opentok-client/dist/opentok.iife.js"></script> -->
-    <script src="https://static.opentok.com/v2/js/opentok.min.js"></script>
+    <script src="https://unpkg.com/daily-opentok-client/dist/opentok.iife.js"></script>
+    <!-- <script src="https://static.opentok.com/v2/js/opentok.min.js"></script> -->
   </head>
   <body>
     <div id="sessionInfo"></div>


### PR DESCRIPTION
While I was working through a demo script I realized demoing joining the call from another window was a little clunky. The extra 15 seconds of effort to copy/paste the URL isn't a big deal normally, but for a presentation, it disrupts the flow a bit. Now, instead of just showing the session ID, it creates a link a user can click on that automatically opens the same session in a new window.

I also fixed a few small eslint issues and made the `require`'s more dynamic